### PR TITLE
解释待决名在实例化前后的问题

### DIFF
--- a/md/第一部分-基础知识/09待决名.md
+++ b/md/第一部分-基础知识/09待决名.md
@@ -110,7 +110,7 @@ void foo(const std::vector<T>& v){
 
 int main(){
     std::vector<int>v;
-    foo(v);
+    foo(v); // 实例化失败
 }
 ```
 
@@ -120,10 +120,10 @@ iter_t 是待决名，但已知它是类型名
 
 > 除非使用关键词 typename 或它**已经被设立为类型名**（例如用 typedef 声明或通过用作基类名）
 
-值得一提的是，以上代码在 gcc 无法通过编译，它没办法解析 `std::vector<T>::const_iterator* p`；
+值得一提的是，只有在添加 `foo(v)`，即进行模板实例化后 gcc/clang 才会拒绝该程序；
 如果你测试过 msvc 的话，会注意到，` typedef typename std::vector<T>::const_iterator iter_t;` 这一句，即使不加 `typename` 一样可以通过编译；
 
-gcc 没怎么遵守规定，不过一般也不会那样写，msvc 搞特殊，我们知道就行；不要只测 msvc，不然代码不可跨平台。
+msvc 搞特殊，我们知道就行；不要只测 msvc，不然代码不可跨平台。
 
 > 关键词 typename 只能以这种方式用于限定名（例如 T::x）之前，但这些名字**不必待决**。
 


### PR DESCRIPTION
GCC 及 Clang 没有问题，而且和 cppreference 是一致的，见此[链接](https://godbolt.org/z/d61avfqGr)。

那个例子的意思是**不进行实例化时**，模板定义能通过编译。